### PR TITLE
Add back patch for null resource exception

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+
+0.1.5 (2019-11-18)
+------------------
+
+* Add back in patch command to fix issue https://github.com/duo-labs/cloudmapper/issues/540
+* The issue is that publicly accessible RDS instances have .DBSubnetGroup.Subnets set to null.
+
 0.1.4 (2019-11-15)
 ------------------
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,9 @@ COPY manheim_cloudmapper/* /opt/manheim_cloudmapper/
 COPY manheim_cloudmapper/port_check/ /opt/manheim_cloudmapper/port_check/
 COPY manheim_cloudmapper/ses/ /opt/manheim_cloudmapper/ses/
 
+# Patch to fix this issue https://github.com/duo-labs/cloudmapper/issues/540
+RUN patch /opt/manheim_cloudmapper/shared/nodes.py < nodes.patch
+
 RUN chmod +x /opt/manheim_cloudmapper/cloudmapper.sh
 
 RUN pip install pipenv

--- a/manheim_cloudmapper/version.py
+++ b/manheim_cloudmapper/version.py
@@ -17,7 +17,7 @@ manheim-cloudmapper version configuration.
 """
 
 #: The semver-compliant version of the package.
-VERSION = '0.1.4'
+VERSION = '0.1.5'
 
 #: The URL for further information about the package.
 PROJECT_URL = 'https://github.com/manheim/manheim-cloudmapper'


### PR DESCRIPTION
Adding back in the patch command from v0.1.2
I have found that after fixing the Throttling errors, we are still seeing the following error
```
EVENTS	1573983924373	Running cloudmapper.py report on manheim-dev	1573983922830
EVENTS	1573985475013	* Getting resource counts	1573985474544
EVENTS	1573985475013	  - manheim-dev	1573985474544
EVENTS	1573985475013	* Getting IAM data	1573985474544
EVENTS	1573985475013	  - manheim-dev	1573985474544
EVENTS	1573985475013	* Getting public resource data	1573985474544
EVENTS	1573985475013	  - manheim-dev	1573985474544
EVENTS	1573985475013	Traceback (most recent call last):	1573985474545
EVENTS	1573985475013	  File "cloudmapper.py", line 72, in <module>	1573985474545
EVENTS	1573985475013	    main()	1573985474545
EVENTS	1573985475013	  File "cloudmapper.py", line 66, in main	1573985474545
EVENTS	1573985475013	    commands[command].run(arguments)	1573985474545
EVENTS	1573985475013	  File "/opt/manheim_cloudmapper/commands/report.py", line 471, in run	1573985474545
EVENTS	1573985475013	    report(accounts, config, args)	1573985474545
EVENTS	1573985475013	  File "/opt/manheim_cloudmapper/commands/report.py", line 263, in report	1573985474545
EVENTS	1573985475013	    public_nodes, _ = get_public_nodes(account, config, use_cache=True)	1573985474545
EVENTS	1573985475013	  File "/opt/manheim_cloudmapper/shared/public.py", line 89, in get_public_nodes	1573985474545
EVENTS	1573985475013	    network = build_data_structure(account, config, outputfilter)	1573985474545
EVENTS	1573985475013	  File "/opt/manheim_cloudmapper/commands/prepare.py", line 477, in build_data_structure	1573985474545
EVENTS	1573985475013	    add_node_to_subnets(region, node, nodes)	1573985474545
EVENTS	1573985475013	  File "/opt/manheim_cloudmapper/commands/prepare.py", line 329, in add_node_to_subnets	1573985474545
EVENTS	1573985475013	    if len(node.subnets) == 0 and vpc.local_id == node._parent.local_id:	1573985474545
EVENTS	1573985475013	  File "/opt/manheim_cloudmapper/shared/nodes.py", line 498, in subnets	1573985474545
EVENTS	1573985475013	    ".DBSubnetGroup.Subnets[].SubnetIdentifier", self._json_blob	1573985474545
EVENTS	1573985475013	  File "/root/.local/share/virtualenvs/manheim_cloudmapper-m747ExVH/lib/python3.7/site-packages/pyjq.py", line 49, in all	1573985474545
EVENTS	1573985475013	    return compile(script, vars, library_paths).all(_get_value(value, url, opener))	1573985474545
EVENTS	1573985475013	  File "_pyjq.pyx", line 209, in _pyjq.Script.all (_pyjq.c:2561)	1573985474545
EVENTS	1573985475013	_pyjq.ScriptRuntimeError: Cannot iterate over null (null)	1573985474545
```

I believe when we have publicly accessible RDS instances, they have `.DBSubnetGroup.Subnets` set to `null`