### PR TITLE
Skip generating report when SES is not enabled

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+0.1.6 (2019-11-21)
+------------------
+
+* Skip cloudmapper report step when SES is not enabled
+
 
 0.1.5 (2019-11-18)
 ------------------

--- a/manheim_cloudmapper/cloudmapper.sh
+++ b/manheim_cloudmapper/cloudmapper.sh
@@ -14,8 +14,10 @@ cat config.json
 echo "Running cloudmapper.py collect on $ACCOUNT"
 pipenv run python cloudmapper.py collect --account $ACCOUNT || true
 
-echo "Running cloudmapper.py report on $ACCOUNT"
-pipenv run python cloudmapper.py report --account $ACCOUNT
+if [ $SES_ENABLED == 'true' ]; then
+    echo "Running cloudmapper.py report on $ACCOUNT"
+    pipenv run python cloudmapper.py report --account $ACCOUNT
+fi
 
 echo "Running cloudmapper.py public scan on $ACCOUNT"
 pipenv run python cloudmapper.py public --account $ACCOUNT > $ACCOUNT.json

--- a/manheim_cloudmapper/version.py
+++ b/manheim_cloudmapper/version.py
@@ -17,7 +17,7 @@ manheim-cloudmapper version configuration.
 """
 
 #: The semver-compliant version of the package.
-VERSION = '0.1.5'
+VERSION = '0.1.6'
 
 #: The URL for further information about the package.
 PROJECT_URL = 'https://github.com/manheim/manheim-cloudmapper'


### PR DESCRIPTION
We only need to run `cloudmapper.py` report when we plan to send the report out via SES. We can skip this step if SES is not set to 'true'. This will cut down on the run-time of cloudmapper. 