### PR TITLE
Enable debug mode for cloudmapper

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+0.1.7 (2019-11-25)
+------------------
+
+* Skip cloudmapper collect step when SES is not enabled.
+* Only run public port check unless otherwise specified.
+* Enable DEBUG output for cloudmapper public runs
+
 0.1.6 (2019-11-21)
 ------------------
 

--- a/manheim_cloudmapper/cloudmapper.sh
+++ b/manheim_cloudmapper/cloudmapper.sh
@@ -11,16 +11,16 @@ echo "S3 Copy successful!"
 echo "config.json: "
 cat config.json
 
-echo "Running cloudmapper.py collect on $ACCOUNT"
-pipenv run python cloudmapper.py collect --account $ACCOUNT || true
-
 if [ $SES_ENABLED == 'true' ]; then
+    echo "Running cloudmapper.py collect on $ACCOUNT"
+    pipenv run python cloudmapper.py collect --account $ACCOUNT || true
+
     echo "Running cloudmapper.py report on $ACCOUNT"
     pipenv run python cloudmapper.py report --account $ACCOUNT
 fi
 
 echo "Running cloudmapper.py public scan on $ACCOUNT"
-pipenv run python cloudmapper.py public --account $ACCOUNT > $ACCOUNT.json
+pipenv run python cloudmapper.py public --log_level DEBUG --account $ACCOUNT > $ACCOUNT.json
 
 echo "Running check on bad ports for $ACCOUNT"
 mv /opt/manheim_cloudmapper/run_port_check.py /opt/run_port_check.py

--- a/manheim_cloudmapper/version.py
+++ b/manheim_cloudmapper/version.py
@@ -17,7 +17,7 @@ manheim-cloudmapper version configuration.
 """
 
 #: The semver-compliant version of the package.
-VERSION = '0.1.6'
+VERSION = '0.1.7'
 
 #: The URL for further information about the package.
 PROJECT_URL = 'https://github.com/manheim/manheim-cloudmapper'


### PR DESCRIPTION
Enabling debug mode for cloudmapper public scans to figure out what is going wrong in the legacy dev accounts. Also skipping the collect step (which is not required for `collect`) unless the SES report is to be sent out. 