### PR TITLE
Releasing new 0.2.1 tag

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+0.2.1 (2019-12-03)
+------------------
+
+* Releasing new tag to fix Docker hub build caching issue
+
 0.2.0 (2019-12-03)
 ------------------
 

--- a/manheim_cloudmapper/version.py
+++ b/manheim_cloudmapper/version.py
@@ -17,7 +17,7 @@ manheim-cloudmapper version configuration.
 """
 
 #: The semver-compliant version of the package.
-VERSION = '0.2.0'
+VERSION = '0.2.1'
 
 #: The URL for further information about the package.
 PROJECT_URL = 'https://github.com/manheim/manheim-cloudmapper'


### PR DESCRIPTION
Docker build caching has been disabled, releasing new tag for build without caching