### PR TITLE
update README for migration to travis-ci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 manheim-cloudmapper
 =================
 
-[![TravisCI build badge](https://api.travis-ci.org/manheim/manheim-cloudmapper.png?branch=master)](https://travis-ci.org/manheim/manheim-cloudmapper)
+[![TravisCI build badge](https://api.travis-ci.com/manheim/manheim-cloudmapper.svg?branch=master)](https://travis-ci.com/github/manheim/manheim-cloudmapper)
 
 [![Docker Hub Build Status](https://img.shields.io/docker/cloud/build/manheim/manheim-cloudmapper.svg)](https://hub.docker.com/r/manheim/manheim-cloudmapper)
 
@@ -9,7 +9,7 @@ Manheim's Cloudmapper Docker image
 
 This project provides a Docker image for managing Manheim's cloudmapper automation. This project/repository is intended to be used (via the generated Docker image) alongside a terraform module which runs the Docker image in AWS ECS on a schedulued cycle.
 
-* TravisCI Builds: <https://travis-ci.org/manheim/manheim-cloudmapper>
+* TravisCI Builds: <https://travis-ci.com/github/manheim/manheim-cloudmapper>
 * Docker image: <https://hub.docker.com/r/manheim/manheim-cloudmapper>
 
 For documentation on the upstream cloudmapper project, please see <https://github.com/duo-labs/cloudmapper>

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,0 @@
-[pytest]
-pep8ignore = 
-	   lib/* ALL
-	   lib64/* ALL
-       manheim_cloudmapper/vendor/* ALL
-pep8maxlinelength = 80
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[pycodestyle]
+exclude = lib/*,lib64/*
+max-line-length = 80

--- a/tox.ini
+++ b/tox.ini
@@ -6,12 +6,12 @@ deps =
   cov-core
   coverage
   execnet
-  pep8
+  pycodestyle
   py
   pytest>=2.8.3
   pytest-cache
   pytest-cov
-  pytest-pep8
+  pytest-pycodestyle
   pytest-flakes
   pytest-html
   mock
@@ -32,7 +32,7 @@ commands =
     virtualenv --version
     pip --version
     pip freeze
-    py.test -rxs -vv --durations=10 --pep8 --flakes --blockage --cov-report term-missing --cov-report xml --cov-report html --cov-config {toxinidir}/.coveragerc --cov=manheim_cloudmapper --junitxml=testresults.xml --html=testresults.html {posargs} manheim_cloudmapper
+    py.test -rxs -vv --durations=10 --pycodestyle --flakes --blockage --cov-report term-missing --cov-report xml --cov-report html --cov-config {toxinidir}/.coveragerc --cov=manheim_cloudmapper --junitxml=testresults.xml --html=testresults.html {posargs} manheim_cloudmapper
 
 [testenv:docker]
 setenv =


### PR DESCRIPTION
This repository has been migrated from travis-ci.org to travis-ci.com. This PR just updates the README accordingly.

This also switches from deprecated pep8 to pycodestyle, to make tests pass.